### PR TITLE
fix: Replace folium tiles to available ones

### DIFF
--- a/atlas_tools/dns_map.py
+++ b/atlas_tools/dns_map.py
@@ -32,7 +32,7 @@ def _make_map(ping_results, fname):
     dns_map = folium.Map(
         location=[20, 20],
         zoom_start=2, max_zoom=10, min_zoom=2,
-        tiles='Mapbox Bright'
+        tiles='Stamen Terrain',
     )
 
     resolves_counters = defaultdict(int)

--- a/atlas_tools/latency_countrymap.py
+++ b/atlas_tools/latency_countrymap.py
@@ -57,7 +57,7 @@ def _draw_countrymap(cut_countries, fname):
     countrymap = folium.Map(
         location=[20, 20],
         zoom_start=3, min_zoom=2, max_zoom=8,
-        tiles='Mapbox Bright'
+        tiles='Stamen Terrain',
     )
 
     folium.GeoJson(


### PR DESCRIPTION
Mapbox tiles are currently available only with personal API keys.

This PR proposes using Stamen tiles insted.